### PR TITLE
Add support for Function.prototype.call and apply

### DIFF
--- a/spec/loophole-spec.coffee
+++ b/spec/loophole-spec.coffee
@@ -11,3 +11,15 @@ describe "Loophole", ->
       allowUnsafeNewFunction ->
         f = new Function("a, b", "c", "return a + b + c;")
         expect(f(1, 2, 3)).toBe 6
+
+    it "supports Function.prototype.call", ->
+      allowUnsafeNewFunction ->
+        expect(Function::call).toBeDefined()
+        f = new Function("a, b", "c", "return a + b + c;")
+        expect(Function::call.call(f, null, 1, 2, 3)).toBe 6
+
+    it "supports Function.prototype.apply", ->
+      allowUnsafeNewFunction ->
+        expect(Function::apply).toBeDefined()
+        f = new Function("a, b", "c", "return a + b + c;")
+        expect(Function::apply.call(f, null, [1, 2, 3])).toBe 6

--- a/src/loophole.coffee
+++ b/src/loophole.coffee
@@ -28,3 +28,5 @@ exports.Function = (paramLists..., body) ->
       #{body}
     })
   """
+
+exports.Function:: = global.Function::


### PR DESCRIPTION
This is needed for eslint in Atom since some dependency invokes `Function.prototype.call.call`.
